### PR TITLE
[Fix] After login Check error

### DIFF
--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -28,12 +28,12 @@ const LoginForm = () => {
 
   const authLoadable = useRecoilValue(authWithLoginQuery);
   const checkLoadable = useRecoilValue(userWithCheckQuery);
-  const { auth, authError } = useRecoilValue(authResultAtom);
+  const { authError } = useRecoilValue(authResultAtom);
   const { user, checkError } = useRecoilValue(userAtom);
 
+  const setResetUser = useResetRecoilState(userAtom);
   const setResetAuth = useResetRecoilState(authResultAtom);
   const resetAuthStatusState = useResetRecoilState(authFormStatusAtom);
-  const setResetUser = useResetRecoilState(userAtom);
 
   const snackbar = (variant) => (message) => enqueueSnackbar(message, { variant });
   const errorSnackbar = snackbar('error');
@@ -69,7 +69,7 @@ const LoginForm = () => {
       errorSnackbar('Failure Sign in!');
       setResetAuth();
     }
-  }, [auth, authError]);
+  }, [authError]);
 
   useEffect(() => {
     if (user) {

--- a/src/components/user-info/UserStatus.jsx
+++ b/src/components/user-info/UserStatus.jsx
@@ -35,10 +35,10 @@ const AuthButtonsWrapper = styled.div`
 const UserStatus = () => {
   const { enqueueSnackbar } = useSnackbar();
 
+  const { user } = useRecoilValue(userAtom);
   const [loadable, setLogout] = useRecoilState(authWithLogoutQuery);
   const [{ type }, setAuthStatus] = useRecoilState(authFormStatusAtom);
 
-  const { user } = useRecoilValue(userAtom);
   const setLogoutResult = useSetRecoilState(userWithHandle);
   const resetAuthFormStatus = useResetRecoilState(authFormStatusAtom);
 

--- a/src/recoil/user/withCheck.js
+++ b/src/recoil/user/withCheck.js
@@ -1,13 +1,13 @@
-import { selector, noWait } from 'recoil';
+import { selector, noWait, selectorFamily } from 'recoil';
 
 import { authResultAtom } from '../auth';
 
 import { check } from '../../services/api/auth';
 import recoilLoadable from '../../utils/recoil/recoilLoadable';
 
-const userWithCheck = selector({
+const userWithCheck = selectorFamily({
   key: 'userWithCheck',
-  get: async () => {
+  get: () => async () => {
     const response = await check();
 
     return response;
@@ -23,7 +23,7 @@ const userWithCheckQuery = selector({
       return null;
     }
 
-    const loadable = recoilLoadable(get(noWait(userWithCheck)));
+    const loadable = recoilLoadable(get(noWait(userWithCheck(auth))));
 
     return loadable;
   },


### PR DESCRIPTION
- Change selector to selectorFamily
- 한 아이디로 로그인, 로그아웃 후 다른 아이디로 로그인시 전에 로그인 했던 아이디가 로그인 되던 문제 해결
- 문제 원인은 recoil selector가 cache를 사용하는데 selector는 key와 get 의존성 값으로만 캐시키의 동일성을 확인할 것이여서 이전의 check api는 다음과 같은데 이러면 기존 값과 동일하다고 보기 때문에 cache가 적용되어 `userWithCheck`를 실행하지 않고 기존의 값이 반환된다.

```js
const userWithCheck = selector({
  key: 'userWithCheck',
  get: async () => {
    const response = await check();

    return response;
  },
});
```

- 때문에 다음과 같이 `selectorFamily`를 사용하여 해결하였는데 `selectorFamily`는 캐시 값을 확인할 때 파라미터와 key값과 get의존성을 확인하기 때문에 auth를 파라미터를 넘겨 cache가 안되게 해결해였다. 근데 더 좋은 방법이 있을 거 같다. 

```js
const userWithCheck = selectorFamily({
  key: 'userWithCheck',
  get: () => async () => {
    const response = await check();

    return response;
  },
});

const userWithCheckQuery = selector({
  key: 'userWithCheckQuery',
  get: ({ get }) => {
    const { auth } = get(authResultAtom);

    if (!auth) {
      return null;
    }

    const loadable = recoilLoadable(get(noWait(userWithCheck(auth))));

    return loadable;
  },
});
```