### PR TITLE
[Fix] Auth Check Logic

### DIFF
--- a/src/components/auth/AuthModalForm.jsx
+++ b/src/components/auth/AuthModalForm.jsx
@@ -12,7 +12,7 @@ import palette from '../../styles/palette';
 
 import { FORM_TYPE } from '../../utils/constants/constants';
 
-import authFieldsAtom, { authFormStatusAtom } from '../../recoil/auth';
+import { authFormStatusAtom } from '../../recoil/auth';
 
 import CloseIcon from '../../assets/icons/close.svg';
 import AuthInput from './AuthInput';
@@ -103,13 +103,7 @@ const AuthModalForm = ({ onSubmit }) => {
 
   const { type, visible } = useRecoilValue(authFormStatusAtom);
 
-  const resetAuthStatusState = useResetRecoilState(authFormStatusAtom);
-  const resetAuthFieldsState = useResetRecoilState(authFieldsAtom);
-
-  const onCloseAuthModal = () => {
-    resetAuthStatusState();
-    resetAuthFieldsState();
-  };
+  const onCloseAuthModal = useResetRecoilState(authFormStatusAtom);
 
   const formType = FORM_TYPE[type];
 

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -9,9 +9,7 @@ import { FORM_TYPE } from '../../utils/constants/constants';
 import { EMPTY_AUTH_INPUT } from '../../utils/constants/messages';
 
 import userAtom from '../../recoil/user';
-import {
-  authResultAtom, authFormStatusAtom, authWithLogin,
-} from '../../recoil/auth';
+import authResultAtom, { authFormStatusAtom, authWithLogin } from '../../recoil/auth';
 
 import useAuthCallback from '../../hooks/useAuthCallback';
 import useCheckCallback from '../../hooks/useCheckCallback';

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -4,7 +4,7 @@ import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import { useSnackbar } from 'notistack';
 
-import { authResultAtom, authFormStatusAtom, authWithRegister } from '../../recoil/auth';
+import authResultAtom, { authFormStatusAtom, authWithRegister } from '../../recoil/auth';
 
 import useAuthCallback from '../../hooks/useAuthCallback';
 

--- a/src/components/common/AuthStatusSnackbar.jsx
+++ b/src/components/common/AuthStatusSnackbar.jsx
@@ -4,7 +4,7 @@ import { useRecoilState } from 'recoil';
 
 import { useSnackbar } from 'notistack';
 
-import { authResultAtom } from '../../recoil/auth';
+import authResultAtom from '../../recoil/auth';
 
 const AuthStatusSnackbar = () => {
   const [{ authSuccess, authError }, setAuthState] = useRecoilState(authResultAtom);

--- a/src/components/common/InjectTestingRecoilState.jsx
+++ b/src/components/common/InjectTestingRecoilState.jsx
@@ -4,7 +4,7 @@ import { useSetRecoilState } from 'recoil';
 
 import userAtom from '../../recoil/user';
 import todosResultAtom, { filterAtom } from '../../recoil/todos';
-import authFieldsAtom, { authFormStatusAtom, authResultAtom } from '../../recoil/auth';
+import authResultAtom, { authFormStatusAtom } from '../../recoil/auth';
 import isLoadingAtom from '../../recoil/common/atom';
 
 import {
@@ -16,7 +16,6 @@ const InjectTestingRecoilState = ({
   filter = 'ALL',
   user = userState,
   auth = authState,
-  authFields = null,
   authResult = authResultState,
   isLoading = false,
 }) => {
@@ -24,7 +23,6 @@ const InjectTestingRecoilState = ({
   const setFilterState = useSetRecoilState(filterAtom);
   const setUserState = useSetRecoilState(userAtom);
   const setAuthState = useSetRecoilState(authFormStatusAtom);
-  const setAuthFieldsState = useSetRecoilState(authFieldsAtom);
   const setAuthResultState = useSetRecoilState(authResultAtom);
   const setLoadingState = useSetRecoilState(isLoadingAtom);
 
@@ -33,7 +31,6 @@ const InjectTestingRecoilState = ({
     setAuthState(auth);
     setTodosState(todos);
     setFilterState(filter);
-    setAuthFieldsState(authFields);
     setAuthResultState(authResult);
     setLoadingState(isLoading);
   }, []);

--- a/src/components/user-info/UserStatus.jsx
+++ b/src/components/user-info/UserStatus.jsx
@@ -36,12 +36,10 @@ const UserStatus = () => {
   const setAuthStatus = useSetRecoilState(authFormStatusAtom);
   const setLogout = useSetRecoilState(authWithLogout);
 
-  const onClickOpenModal = (formType) => {
-    setAuthStatus({
-      type: formType,
-      visible: true,
-    });
-  };
+  const onClickOpenModal = (formType) => setAuthStatus({
+    type: formType,
+    visible: true,
+  });
 
   if (user) {
     return (

--- a/src/hooks/useAuthCallback.js
+++ b/src/hooks/useAuthCallback.js
@@ -1,9 +1,10 @@
 import { useRecoilCallback } from 'recoil';
 
 import isLoadingAtom from '../recoil/common/atom';
-import { authResultAtom } from '../recoil/auth';
+import authResultAtom from '../recoil/auth';
 
-import { authErrorMessages } from '../utils/errorMessageHandling';
+import { authErrorMessage } from '../utils/errorMessageHandling';
+
 import { setCookie } from '../services/cookie';
 
 const useAuthCallback = (authType) => useRecoilCallback(({
@@ -26,7 +27,7 @@ const useAuthCallback = (authType) => useRecoilCallback(({
   } catch (error) {
     set(authResultAtom, (prevState) => ({
       ...prevState,
-      authError: authErrorMessages(error),
+      authError: authErrorMessage(error),
     }));
   } finally {
     reset(isLoadingAtom);

--- a/src/hooks/useCheckCallback.js
+++ b/src/hooks/useCheckCallback.js
@@ -4,7 +4,7 @@ import userAtom, { userWithCheck } from '../recoil/user';
 import isLoadingAtom from '../recoil/common/atom';
 
 import { removeItem } from '../services/storage';
-import { removeCookie } from '../services/cookie';
+import { removeCookie, getCookie } from '../services/cookie';
 
 const useCheckCallback = () => useRecoilCallback(({
   snapshot, set, reset,
@@ -12,7 +12,7 @@ const useCheckCallback = () => useRecoilCallback(({
   set(isLoadingAtom, true);
 
   try {
-    const { data } = await snapshot.getPromise(userWithCheck());
+    const { data } = await snapshot.getPromise(userWithCheck(getCookie('access_token')));
 
     set(userAtom, (prevState) => ({
       ...prevState,

--- a/src/recoil/auth/atom.js
+++ b/src/recoil/auth/atom.js
@@ -1,8 +1,6 @@
 import { atom } from 'recoil';
 
-import {
-  AUTH_FIELDS_ATOM_KEY, AUTH_FORM_STATUS_ATOM_KEY, AUTH_RESULT_ATOM_KEY,
-} from '../../utils/constants/atomKey';
+import { AUTH_FORM_STATUS_ATOM_KEY, AUTH_RESULT_ATOM_KEY } from '../../utils/constants/atomKey';
 
 export const authFormStatusAtom = atom({
   key: AUTH_FORM_STATUS_ATOM_KEY,
@@ -12,7 +10,7 @@ export const authFormStatusAtom = atom({
   },
 });
 
-export const authResultAtom = atom({
+const authResultAtom = atom({
   key: AUTH_RESULT_ATOM_KEY,
   default: {
     auth: null,
@@ -21,9 +19,4 @@ export const authResultAtom = atom({
   },
 });
 
-const authFieldsAtom = atom({
-  key: AUTH_FIELDS_ATOM_KEY,
-  default: null,
-});
-
-export default authFieldsAtom;
+export default authResultAtom;

--- a/src/recoil/auth/index.js
+++ b/src/recoil/auth/index.js
@@ -1,15 +1,14 @@
-import authFieldsAtom, { authFormStatusAtom, authResultAtom } from './atom';
+import authResultAtom, { authFormStatusAtom } from './atom';
 
 import authWithLogin from './withLogin';
 import authWithLogout from './withLogout';
 import authWithRegister from './withRegister';
 
 export {
-  authResultAtom,
   authFormStatusAtom,
   authWithLogout,
   authWithLogin,
   authWithRegister,
 };
 
-export default authFieldsAtom;
+export default authResultAtom;

--- a/src/recoil/user/withCheck.js
+++ b/src/recoil/user/withCheck.js
@@ -4,8 +4,8 @@ import { check } from '../../services/api/auth';
 
 const userWithCheck = selectorFamily({
   key: 'userWithCheck',
-  get: () => async () => {
-    const response = await check();
+  get: (token) => async () => {
+    const response = await check(token);
 
     return response;
   },

--- a/src/recoil/user/withCheck.test.js
+++ b/src/recoil/user/withCheck.test.js
@@ -16,9 +16,11 @@ describe('authWithLogin', () => {
   it('Should Call api check', async () => {
     const initialSnapshot = snapshot_UNSTABLE();
 
-    const response = await initialSnapshot.getPromise(userWithCheck());
+    const response = await initialSnapshot.getPromise(userWithCheck('token'));
 
     expect(response).toBe(data);
-    expect(mockAxios.get).toBeCalledWith('/api/auth/check');
+    expect(mockAxios.get).toBeCalledWith('/api/auth/check', {
+      headers: { Authorization: 'token' },
+    });
   });
 });

--- a/src/services/api/auth.js
+++ b/src/services/api/auth.js
@@ -18,4 +18,8 @@ export const login = ({
   password,
 });
 
-export const check = () => client.get(`${AUTH_PATH}/check`);
+export const check = (token) => client.get(`${AUTH_PATH}/check`, {
+  headers: {
+    Authorization: token,
+  },
+});

--- a/src/utils/constants/atomKey.js
+++ b/src/utils/constants/atomKey.js
@@ -2,8 +2,6 @@ export const TODOS_ATOM_KEY = 'todosAtom';
 
 export const FILTER_ATOM_KEY = 'filterAtom';
 
-export const AUTH_FIELDS_ATOM_KEY = 'authFieldsAtom';
-
 export const AUTH_RESULT_ATOM_KEY = 'authResultAtom';
 
 export const AUTH_FORM_STATUS_ATOM_KEY = 'authFormStatusAtom';

--- a/src/utils/errorMessageHandling.js
+++ b/src/utils/errorMessageHandling.js
@@ -1,28 +1,6 @@
 import { TODO_ERROR, AUTH_ERROR } from './constants/messages';
 
-export const authErrorMessage = (auth) => ({ status, data }) => {
-  const { UNAUTHORIZED, CONFLICT, INTERNAL_SERVER_ERROR } = AUTH_ERROR;
-
-  if (status === 400) {
-    return data.details[0].message;
-  }
-
-  if (status === 401) {
-    return UNAUTHORIZED;
-  }
-
-  if (status === 409) {
-    return CONFLICT;
-  }
-
-  if (status === 500) {
-    return INTERNAL_SERVER_ERROR;
-  }
-
-  return `Failure ${auth}!`;
-};
-
-export const authErrorMessages = ({ response }) => {
+export const authErrorMessage = ({ response }) => {
   const {
     UNAUTHORIZED, CONFLICT, INTERNAL_SERVER_ERROR, SOMETHING_WRONG,
   } = AUTH_ERROR;

--- a/src/utils/errorMessageHandling.test.js
+++ b/src/utils/errorMessageHandling.test.js
@@ -1,79 +1,6 @@
-import { todoErrorMessage, authErrorMessage, authErrorMessages } from './errorMessageHandling';
+import { todoErrorMessage, authErrorMessage } from './errorMessageHandling';
 
 describe('authErrorMessage', () => {
-  const setErrorMessage = authErrorMessage('Sign in');
-
-  describe('status is 400', () => {
-    const errorStatus = {
-      status: 400,
-      data: {
-        details: [{
-          message: '빈 값이 존재합니다.',
-        }],
-      },
-    };
-
-    it('Error message should be "빈 값이 존재합니다."', () => {
-      const errorMessage = setErrorMessage(errorStatus);
-
-      expect(errorMessage).toBe(errorStatus.data.details[0].message);
-    });
-  });
-
-  describe('status is 409', () => {
-    const errorStatus = {
-      status: 409,
-      data: '',
-    };
-
-    it('Error message should be "이미 존재하는 아이디입니다."', () => {
-      const errorMessage = setErrorMessage(errorStatus);
-
-      expect(errorMessage).toBe('이미 존재하는 아이디입니다.');
-    });
-  });
-
-  describe('status is 401', () => {
-    const errorStatus = {
-      status: 401,
-      data: '',
-    };
-
-    it('Error message should be "아이디 또는 비밀번호가 다릅니다."', () => {
-      const errorMessage = setErrorMessage(errorStatus);
-
-      expect(errorMessage).toBe('아이디 또는 비밀번호가 다릅니다.');
-    });
-  });
-
-  describe('status is 500', () => {
-    const errorStatus = {
-      status: 500,
-      data: '',
-    };
-
-    it('Error message should be "서버에 문제가 발생하였습니다. 관리자에게 문의하세요."', () => {
-      const errorMessage = setErrorMessage(errorStatus);
-
-      expect(errorMessage).toBe('서버에 문제가 발생하였습니다. 관리자에게 문의하세요.');
-    });
-  });
-
-  describe('Another status', () => {
-    const errorStatus = {
-      status: 403,
-      data: '',
-    };
-
-    it('Error message should be "Failure Sign in!"', () => {
-      const errorMessage = setErrorMessage(errorStatus);
-
-      expect(errorMessage).toBe('Failure Sign in!');
-    });
-  });
-});
-
-describe('authErrorMessages', () => {
   const setErrorStatus = (status, data) => ({
     response: {
       status,
@@ -88,7 +15,7 @@ describe('authErrorMessages', () => {
     });
 
     it('Error message should be "빈 값이 존재합니다."', () => {
-      const errorMessage = authErrorMessages(errorStatus);
+      const errorMessage = authErrorMessage(errorStatus);
 
       expect(errorMessage).toBe('빈 값이 존재합니다.');
     });
@@ -98,7 +25,7 @@ describe('authErrorMessages', () => {
     const errorStatus = setErrorStatus(409, '');
 
     it('Error message should be "이미 존재하는 아이디입니다."', () => {
-      const errorMessage = authErrorMessages(errorStatus);
+      const errorMessage = authErrorMessage(errorStatus);
 
       expect(errorMessage).toBe('이미 존재하는 아이디입니다.');
     });
@@ -108,7 +35,7 @@ describe('authErrorMessages', () => {
     const errorStatus = setErrorStatus(401, '');
 
     it('Error message should be "아이디 또는 비밀번호가 다릅니다."', () => {
-      const errorMessage = authErrorMessages(errorStatus);
+      const errorMessage = authErrorMessage(errorStatus);
 
       expect(errorMessage).toBe('아이디 또는 비밀번호가 다릅니다.');
     });
@@ -118,7 +45,7 @@ describe('authErrorMessages', () => {
     const errorStatus = setErrorStatus(500, '');
 
     it('Error message should be "서버에 문제가 발생하였습니다. 관리자에게 문의하세요."', () => {
-      const errorMessage = authErrorMessages(errorStatus);
+      const errorMessage = authErrorMessage(errorStatus);
 
       expect(errorMessage).toBe('서버에 문제가 발생하였습니다. 관리자에게 문의하세요.');
     });
@@ -128,7 +55,7 @@ describe('authErrorMessages', () => {
     const errorStatus = setErrorStatus(403, '');
 
     it('Error message should be "알 수 없는 오류가 생겼습니다.. 잠시 후 다시 시도해주세요!"', () => {
-      const errorMessage = authErrorMessages(errorStatus);
+      const errorMessage = authErrorMessage(errorStatus);
 
       expect(errorMessage).toBe('알 수 없는 오류가 생겼습니다.. 잠시 후 다시 시도해주세요!');
     });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,9 +2,6 @@ import _ from 'lodash';
 
 import { BASE_URL } from './constants/url';
 
-import { removeItem } from '../services/storage';
-import { removeCookie } from '../services/cookie';
-
 export const updateTodos = (todos, newTodo) => todos.map((todo) => {
   if (todo._id === newTodo._id) {
     return newTodo;
@@ -43,21 +40,3 @@ export const isCheckValidate = (inputValue) => Object
 
 export const isEqualPassword = ({ password, passwordConfirm }) => passwordConfirm
   && (password !== passwordConfirm);
-
-export const userCheckErrorHandling = async (userCheck) => {
-  try {
-    const response = await userCheck;
-
-    return response;
-  } catch (error) {
-    removeItem('user');
-    removeCookie('access_token');
-
-    return {
-      data: {
-        user: null,
-        access_token: null,
-      },
-    };
-  }
-};

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,10 +1,8 @@
 import {
-  filteredTodos, setPath, userCheckErrorHandling, updateTodos,
+  filteredTodos, setPath, updateTodos,
 } from './utils';
 
 import { BASE_URL } from './constants/url';
-
-import { removeItem } from '../services/storage';
 
 jest.mock('../services/storage');
 describe('updateTodos', () => {
@@ -64,26 +62,6 @@ describe('setPath', () => {
     expect(result).toEqual({
       baseURL: BASE_URL,
       withCredentials: true,
-    });
-  });
-});
-
-describe('userCheckErrorHandling', () => {
-  context('Have Error', () => {
-    it('Call localStorage removeItem', () => {
-      try {
-        userCheckErrorHandling(new Promise((_, reject) => reject(new Error('error'))));
-      } catch (error) {
-        expect(removeItem).toBeCalledTimes(1);
-      }
-    });
-  });
-
-  context('Have Success', () => {
-    it('should response data', async () => {
-      const response = await userCheckErrorHandling(new Promise((resolve) => resolve('success')));
-
-      expect(response).toBe('success');
     });
   });
 });


### PR DESCRIPTION
- 리코일 selector의 cache로 인해 user 정보가 변경되지 않던 문제 해결
- check api 호출시 access_token을 넣어 header에 넣어줌으로 cache문제 해결
- 사용하지 않는 auth form atom 삭제, 그에 따른 import 수정
- 사용하지 않는 auth error 처리 로직 삭제