### PR TITLE
[Fix] Error when building webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,8 +75,8 @@ module.exports = {
       banner: `
         Build Date: ${new Date().toLocaleString()}
         Commit Version: ${childProcess.execSync('git rev-parse --short HEAD')}
-        Author: ${childProcess.execSync('git config user.name')}
-        Author-Email: ${childProcess.execSync('git config user.email')}
+        Author: seungmin sa
+        Author-Email: dbd02169@naver.com
       `,
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
- CI/CD를 사용하기 때문에 webpack.BannerPlugin 사용시 childProcess.execSync를 사용 시 에러
- git 명령어를 사용하여 주석을 다는데 git config user.name, user.email이 의미가 없어짐 - 삭제
- Fix Error #75 