### PR TITLE
[Fix] Todo load due to cache

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -188,7 +188,7 @@ describe('App', () => {
         fireEvent.submit(getByTestId('auth-submit-button'));
       });
 
-      expect(container).toHaveTextContent('Success Sign in!');
+      expect(container).toHaveTextContent('Successful Sign in!');
     });
 
     it('render todo list contents', async () => {
@@ -250,6 +250,39 @@ describe('App', () => {
         expect(input).toHaveValue('');
         expect(container).toHaveTextContent('Success in entering To-Do!');
       });
+    });
+
+    it('Success Sign up', async () => {
+      mockPostApi({ data: 'test' });
+
+      const props = {
+        auth: {
+          type: 'register',
+          visible: true,
+        },
+      };
+
+      const input = [
+        { placeholder: '아이디', value: 'test' },
+        { placeholder: '비밀번호', value: 'test' },
+        { placeholder: '비밀번호 확인', value: 'test' },
+      ];
+
+      const {
+        container, getByTestId, getByPlaceholderText,
+      } = renderApp(props);
+
+      await act(async () => {
+        input.forEach(({ placeholder, value }) => {
+          fireEvent.change(getByPlaceholderText(placeholder), { target: { value } });
+        });
+      });
+
+      await act(async () => {
+        fireEvent.submit(getByTestId('auth-submit-button'));
+      });
+
+      expect(container).toHaveTextContent('Successful Sign up!');
     });
   });
 });

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -49,7 +49,7 @@ const LoginForm = () => {
 
   useEffect(() => {
     if (user) {
-      successSnackbar('Success Sign in!');
+      successSnackbar('Successful Sign in!');
       resetAuthFormState();
     }
   }, [user]);

--- a/src/components/auth/LoginForm.test.jsx
+++ b/src/components/auth/LoginForm.test.jsx
@@ -75,7 +75,7 @@ describe('LoginForm', () => {
 
         expect(mockAxios.post).toBeCalledTimes(1);
         expect(mockAxios.get).not.toBeCalled();
-        expect(container).not.toHaveTextContent('Success Sign in!');
+        expect(container).not.toHaveTextContent('Successful Sign in!');
       });
     });
   });

--- a/src/components/input/TodoInput.test.jsx
+++ b/src/components/input/TodoInput.test.jsx
@@ -4,8 +4,6 @@ import mockAxios from 'axios';
 
 import { RecoilRoot } from 'recoil';
 
-import { SnackbarProvider } from 'notistack';
-
 import { act } from 'react-dom/test-utils';
 import { render, fireEvent } from '@testing-library/react';
 
@@ -15,12 +13,10 @@ import InjectTestingRecoilState from '../common/InjectTestingRecoilState';
 describe('TodoInput', () => {
   const renderTodoInput = () => render((
     <RecoilRoot>
-      <SnackbarProvider>
-        <InjectTestingRecoilState
-          user={given.user}
-        />
-        <TodoInput />
-      </SnackbarProvider>
+      <InjectTestingRecoilState
+        user={given.user}
+      />
+      <TodoInput />
     </RecoilRoot>
   ));
 

--- a/src/components/user-info/UserStatus.jsx
+++ b/src/components/user-info/UserStatus.jsx
@@ -4,6 +4,7 @@ import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import styled from '@emotion/styled';
 
+import { useSnackbar } from 'notistack';
 import mq from '../../styles/responsive';
 
 import { FORM_TYPE } from '../../utils/constants/constants';
@@ -36,16 +37,25 @@ const UserStatus = () => {
   const setAuthStatus = useSetRecoilState(authFormStatusAtom);
   const setLogout = useSetRecoilState(authWithLogout);
 
+  const { enqueueSnackbar } = useSnackbar();
+
   const onClickOpenModal = (formType) => setAuthStatus({
     type: formType,
     visible: true,
   });
 
+  const onLogout = () => {
+    setLogout();
+    enqueueSnackbar('Successful Sign out!', {
+      variant: 'success',
+    });
+  };
+
   if (user) {
     return (
       <LoggedInUserInfo
         user={user}
-        onLogout={setLogout}
+        onLogout={onLogout}
       />
     );
   }

--- a/src/components/user-info/UserStatus.test.jsx
+++ b/src/components/user-info/UserStatus.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { RecoilRoot } from 'recoil';
 
+import { SnackbarProvider } from 'notistack';
+
 import { render, fireEvent } from '@testing-library/react';
 
 import UserStatus from './UserStatus';
@@ -10,10 +12,12 @@ import InjectTestingRecoilState from '../common/InjectTestingRecoilState';
 describe('UserStatus', () => {
   const renderUserStatus = () => render((
     <RecoilRoot>
-      <InjectTestingRecoilState
-        user={given.user}
-      />
-      <UserStatus />
+      <SnackbarProvider>
+        <InjectTestingRecoilState
+          user={given.user}
+        />
+        <UserStatus />
+      </SnackbarProvider>
     </RecoilRoot>
   ));
 
@@ -39,6 +43,7 @@ describe('UserStatus', () => {
 
         expect(container).toHaveTextContent('Sign in');
         expect(container).toHaveTextContent('Sign up');
+        expect(container).toHaveTextContent('Successful Sign out!');
       });
     });
   });

--- a/src/hooks/useAuthCallback.js
+++ b/src/hooks/useAuthCallback.js
@@ -21,7 +21,7 @@ const useAuthCallback = (authType) => useRecoilCallback(({
       authResultAtom,
       (prevState) => ({
         ...prevState,
-        authSuccess: `Success ${authType}!`,
+        authSuccess: `Successful ${authType}!`,
       }),
     );
   } catch (error) {

--- a/src/hooks/useLoadCallback.js
+++ b/src/hooks/useLoadCallback.js
@@ -5,13 +5,15 @@ import todosResultAtom, { todosWithLoad } from '../recoil/todos';
 
 import { todoErrorMessage } from '../utils/errorMessageHandling';
 
+import { getCookie } from '../services/cookie';
+
 const useLoadCallback = () => useRecoilCallback(({
   snapshot, set, reset,
 }) => async () => {
   set(isLoadingAtom, true);
 
   try {
-    const { data } = await snapshot.getPromise(todosWithLoad);
+    const { data } = await snapshot.getPromise(todosWithLoad(getCookie('access_token')));
 
     set(
       todosResultAtom,

--- a/src/recoil/todos/withLoad.js
+++ b/src/recoil/todos/withLoad.js
@@ -1,11 +1,11 @@
-import { selector } from 'recoil';
+import { selectorFamily } from 'recoil';
 
 import { list } from '../../services/api/todos';
 
-const todosWithLoad = selector({
+const todosWithLoad = selectorFamily({
   key: 'todosWithLoad',
-  get: async () => {
-    const response = await list();
+  get: (token) => async () => {
+    const response = await list(token);
 
     return response;
   },

--- a/src/recoil/todos/withLoad.test.js
+++ b/src/recoil/todos/withLoad.test.js
@@ -16,9 +16,13 @@ describe('todosWithLoad', () => {
   it('Should Call api load', async () => {
     const initialSnapshot = snapshot_UNSTABLE();
 
-    const response = await initialSnapshot.getPromise(todosWithLoad);
+    const response = await initialSnapshot.getPromise(todosWithLoad('token'));
 
     expect(response).toBe(data);
-    expect(mockAxios.get).toBeCalledWith('/api/todos');
+    expect(mockAxios.get).toBeCalledWith('/api/todos', {
+      headers: {
+        Authorization: 'token',
+      },
+    });
   });
 });

--- a/src/services/api/todos.js
+++ b/src/services/api/todos.js
@@ -4,7 +4,11 @@ import { TODOS_PATH } from '../../utils/constants/url';
 
 export const write = (task) => client.post(TODOS_PATH, { task });
 
-export const list = () => client.get(TODOS_PATH);
+export const list = (token) => client.get(TODOS_PATH, {
+  headers: {
+    Authorization: token,
+  },
+});
 
 export const multipleRemove = (ids) => client.delete(TODOS_PATH, {
   data: { ids },

--- a/src/services/api/todos.test.js
+++ b/src/services/api/todos.test.js
@@ -24,10 +24,14 @@ describe('todos api', () => {
   });
 
   it('GET /api/todos', async () => {
-    const result = await list(data);
+    const result = await list('token');
 
     expect(result).toBe(data);
-    expect(mockAxios.get).toBeCalledWith('/api/todos');
+    expect(mockAxios.get).toBeCalledWith('/api/todos', {
+      headers: {
+        Authorization: 'token',
+      },
+    });
   });
 
   it('DELETE /api/todos/', async () => {


### PR DESCRIPTION
- Recoil의 selector Cache 때문에 Load시 전에 로그인한 사용자의 ToDo가 나오는 현상 수정
- Change Auth Success Message
- Add When Successful Sign out, renders Success message